### PR TITLE
Fixed issue for tagging in firefox

### DIFF
--- a/src/scania.angular.select2.js
+++ b/src/scania.angular.select2.js
@@ -49,6 +49,7 @@
                         options.data = { results: JSON.parse($attr.data), text: $attr.label };
                         options.createSearchChoice = $scope.createSearchChoice;
                         options.tokenSeparators = $scope.tokenSeparators || tokenSeparators;
+                        options.id = $attr.itemId;
                         inputOptionsLabelProperty = options.label;
                     }
                     select = $(tag + '.sc-' + selectorName + '[id="' + $attr.id + '"]');


### PR DESCRIPTION
select2 uses an "id" property from the options object that we provide it through sc-select2. We didn't populate that property, and the tagging functionality did not work since it relied on the id. For other browser than firefox putting data-id on the sc-select2 directive did the trick, but firefox strips the data- in front of the id, and the selec2 cannot find that property on the options object
